### PR TITLE
[chore]: add regex by datetime and Time.parse

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'rake'
+gem 'minitest'
+gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (11.1.3)
+    minitest (5.25.1)
+    rake (13.2.1)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  byebug
+  minitest
+  rake
+
+BUNDLED WITH
+   2.5.18

--- a/README.md
+++ b/README.md
@@ -1,6 +1,37 @@
 # JSON API Active Record Query Adapter
 
-This project parses filters and transforms to active record queries
+This project provides an adapter to transform filters from an API in JSON-API format into ActiveRecord-compatible SQL queries. It is useful for handling complex filters such as date ranges, comparisons, logical operators, and `LIKE` queries.
+
+## Requirements
+
+- Ruby 2.7 or higher
+- ActiveRecord (if integrated with a database)
+- `require 'time'` (necessary for date and time manipulation)
+
+## Installation
+
+1. **Add the gem to your project:**
+
+   Run the following command to add the gem to your `Gemfile`:
+
+   ```bash
+   bundle add json_api_active_record_query_adapter
+
+2. **Add the module to your controller:**
+
+```
+  include JsonApiFilterAdapter
+```
+
+3. **Example to use the method that will process the data in the controller:**
+
+```
+def index
+  filter = parse_filter_adapter(params)
+  @records = Model.where(filter)
+  render json: @records
+end
+```
 
 ## How to test
 

--- a/json_api_active_record_query_adapter.gemspec
+++ b/json_api_active_record_query_adapter.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "json_api_active_record_query_adapter"
-  s.version     = "1.2.4"
+  s.version     = "1.2.5"
   s.date        = "2023-04-19"
   s.summary     = "Syntax query definition and adapter for using with active record."
   s.description = "Syntax query definition and adapter for using with active record."

--- a/lib/json_api_active_record_query_adapter.rb
+++ b/lib/json_api_active_record_query_adapter.rb
@@ -33,7 +33,7 @@ module JsonApiFilterAdapter
       first, last = parameter[VALUE].split('..')
       case parameter[VALUE]
       when /^\d{4}-\d{2}-\d{2}..\d{4}-\d{2}-\d{2}$/ # somente com data
-        data_parsed[parameter[KEY]] = Range.new(Time.parse(first), Time.parse(last))
+        data_parsed[parameter[KEY]] = Range.new(Date.parse(first), Date.parse(last))
       when /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}..\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/ # com data e hora
         data_parsed[parameter[KEY]] = Range.new(Time.parse(first), Time.parse(last))
       when /^\d+..\d+$/
@@ -43,7 +43,7 @@ module JsonApiFilterAdapter
       end
     end
 
-    data.merge(data_parsed)
+    data.merge!(data_parsed)
 
     operator_parser_hash_to_array data
   end
@@ -64,22 +64,21 @@ module JsonApiFilterAdapter
     data.each do |parameter|
       # tratar operador de comparação
       value_downcase = parameter[VALUE].to_s.downcase
-
       if value_downcase.include?('=like=')
         conditional_operator = ':value LIKE ?'
         parameter[VALUE] = "%#{parameter[VALUE]}%"
-      elsif parameter[VALUE].to_s.include?('..')
+      elsif parameter[VALUE].is_a?(Range)
         conditional_operator = ':value BETWEEN ? AND ?'
       elsif parameter[VALUE].is_a?(Array) & !value_downcase.include?('=null=')
         conditional_operator = ':value IN (?)'
       elsif parameter[VALUE].is_a?(Array) && value_downcase.include?('=null=')
         parameter[VALUE] = parameter[VALUE].filter { |v| v != '=null=' }
-        conditional_operator = "(:value IS NULL OR :value IN (?))"
+        conditional_operator = '(:value IS NULL OR :value IN (?))'
       elsif !parameter[VALUE].is_a?(Array) && value_downcase.include?('=null=')
         parameter[VALUE] = nil
         conditional_operator = ':value IS NULL'
       elsif operator = direct_logic_operator(parameter[VALUE])
-        parameter[VALUE].gsub!(operator, "").strip!
+        parameter[VALUE].gsub!(operator, '').strip!
         conditional_operator = ":value #{operator} ?"
       else
         conditional_operator = ':value = ?'
@@ -91,21 +90,21 @@ module JsonApiFilterAdapter
       # saber se esta no final da lista de parametros
       if cont < data.to_hash.size
         # se não tiver no final da lista
-        data_converted_header = "#{data_converted_header} #{conditional_operator} #{query_conditional_operator}".gsub(":value", parameter[KEY])
+        data_converted_header = "#{data_converted_header} #{conditional_operator} #{query_conditional_operator}".gsub(':value', parameter[KEY])
         cont += 1
       else
         # se tiver no final da lista
-        data_converted_header = "#{data_converted_header} #{conditional_operator}".gsub(":value", parameter[KEY])
+        data_converted_header = "#{data_converted_header} #{conditional_operator}".gsub(':value', parameter[KEY])
         cont += 1
       end
     end
+
     data_converted_header.strip!
 
     # criar os demais elementos do vetor que faram referencia em ordem a cada um dos pontos de interrogação
     data.to_hash.each_value do |value|
       # tratando entradas que não são arrays
       unless value.is_a?(Array)
-
         value_modificad = value.to_s.downcase
         # tratar like e or
         if value_modificad.include?('=like=')
@@ -117,12 +116,12 @@ module JsonApiFilterAdapter
           data_converted_value << value_modificad.to_bool
         elsif !value_modificad.include?('=null=')
           # tratar between
-          if value_modificad.include?('..')
-            first, last = value_modificad.split('..')
-            data_converted_value << first
-            data_converted_value << last
+          if value.is_a?(Range)
+            data_converted_value << value.first
+            data_converted_value << value.last
+          else
+            data_converted_value << value_modificad
           end
-          data_converted_value << value_modificad unless value_modificad.include?('..')
         end
       end
       # tratando entradas que são array

--- a/lib/json_api_active_record_query_adapter.rb
+++ b/lib/json_api_active_record_query_adapter.rb
@@ -1,3 +1,5 @@
+# Biblioteca nativa do Ruby para lidar com parsing e formatação de datas e horas, como Time.parse
+require 'time'
 # TODO: Resolver para o caso de ordenação por colunas de tabelas associadas
 
 # Adpta objeto json para hash de consulta compativél com o active_record
@@ -30,8 +32,10 @@ module JsonApiFilterAdapter
 
       first, last = parameter[VALUE].split('..')
       case parameter[VALUE]
-      when /^\d{4}-\d{2}-\d{2}..\d{4}-\d{2}-\d{2}$/
-        data_parsed[parameter[KEY]] = Range.new(Date.parse(first), Date.parse(last))
+      when /^\d{4}-\d{2}-\d{2}..\d{4}-\d{2}-\d{2}$/ # somente com data
+        data_parsed[parameter[KEY]] = Range.new(Time.parse(first), Time.parse(last))
+      when /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}..\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/ # com data e hora
+        data_parsed[parameter[KEY]] = Range.new(Time.parse(first), Time.parse(last))
       when /^\d+..\d+$/
         data_parsed[parameter[KEY]] = Range.new(first.to_i, last.to_i)
       when /^\d+.\d+..\d+.\d+$/

--- a/test/json_api_active_record_query_adapter_test.rb
+++ b/test/json_api_active_record_query_adapter_test.rb
@@ -47,4 +47,14 @@ class JsonApiFilterAdapterTest < Minitest::Test
     assert_equal @_class.parse_filter_adapter({"row.colum1" => ">= '2024-01-01 14:10'"}),
       ["row.colum1 >= ?", "'2024-01-01 14:10'"]
   end
+
+  def test_range_with_dates
+    assert_equal @_class.parse_filter_adapter({"row.colum1" => "2024-01-01..2024-01-31"}),
+    ["row.colum1 BETWEEN ? AND ?", "2024-01-01", "2024-01-31"]
+  end
+  
+  def test_range_with_dates_and_times
+    assert_equal @_class.parse_filter_adapter({"row.colum1" => "2024-01-01 14:10..2024-01-01 16:00"}),
+      ["row.colum1 BETWEEN ? AND ?", "2024-01-01 14:10", "2024-01-01 16:00"]
+  end
 end

--- a/test/json_api_active_record_query_adapter_test.rb
+++ b/test/json_api_active_record_query_adapter_test.rb
@@ -49,12 +49,16 @@ class JsonApiFilterAdapterTest < Minitest::Test
   end
 
   def test_range_with_dates
-    assert_equal @_class.parse_filter_adapter({"row.colum1" => "2024-01-01..2024-01-31"}),
-    ["row.colum1 BETWEEN ? AND ?", "2024-01-01", "2024-01-31"]
+    result = @_class.parse_filter_adapter({ "row.colum1" => "2024-09-05..2024-09-30" })
+    expected = ["row.colum1 BETWEEN ? AND ?", Date.new(2024, 9, 5), Date.new(2024, 9, 30)]
+    
+    assert_equal expected, result
   end
   
   def test_range_with_dates_and_times
-    assert_equal @_class.parse_filter_adapter({"row.colum1" => "2024-01-01 14:10..2024-01-01 16:00"}),
-      ["row.colum1 BETWEEN ? AND ?", "2024-01-01 14:10", "2024-01-01 16:00"]
+    result = @_class.parse_filter_adapter({ "row.colum1" => "2024-09-05 00:00..2024-09-05 23:59" })
+    expected = ["row.colum1 BETWEEN ? AND ?", Time.new(2024, 9, 5, 0, 0, 0), Time.new(2024, 9, 5, 23, 59, 0)]
+    
+    assert_equal expected, result
   end
 end


### PR DESCRIPTION
*[MOTIVAÇÃO]*: 
- Atualmente o comparador Regex para filtros de datas só aceitava `match` sem hora, ou seja, quando passamos uma `data_hora_inicio` junto ao filtro, o comparador falha, pois a hora não está presente e o tratamento é ignorado não chamando o método `Time.parse` para tratar a data.

*[SOLUÇÃO]*: 
- Adicionado um `require 'time'` da classe Time que é **nativa do ruby** para o parse de data
- Adiciona um comparador de Data e Hora na condicional do `case` para suportar esse tipo de formato
- Adiciona Teste unitário para garantir que o comportamento esperado não esteja retornando false positivo
- Complemento do REAME.md