### PR TITLE
[chore]: add time_zone handling to gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 gem 'rake'
 gem 'minitest'
 gem 'byebug'
-gem 'activesupport', '~> 7.0.8'
+gem 'activesupport', '>= 6'

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem 'rake'
 gem 'minitest'
 gem 'byebug'
+gem 'activesupport', '~> 7.0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,29 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.8.4)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
     byebug (11.1.3)
     concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
+    drb (2.2.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    logger (1.6.1)
     minitest (5.25.1)
     rake (13.2.1)
+    securerandom (0.3.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
@@ -20,7 +32,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activesupport (~> 7.0.8)
+  activesupport (>= 6)
   byebug
   minitest
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,26 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.8.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     byebug (11.1.3)
+    concurrent-ruby (1.3.4)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
     minitest (5.25.1)
     rake (13.2.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
 
 PLATFORMS
   ruby
   x86_64-linux
 
 DEPENDENCIES
+  activesupport (~> 7.0.8)
   byebug
   minitest
   rake

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ def index
   render json: @records
 end
 ```
+## Configuring Time Zone for JsonApiFilterAdapter
+
+To use the `time_zone` feature correctly after installing the gem, you need to create an initializer file and add the following configuration:
+
+```ruby
+# config/initializers/json_api_filter_adapter.rb
+
+# Sets the gem's timezone based on the Time.zone configured by the application
+Rails.application.config.after_initialize do
+  JsonApiFilterAdapter.time_zone = ActiveSupport::TimeZone['America/Sao_Paulo']
+end
+```
 
 ## About date filters and the use of `Time.use_zone` in the Code
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ This project provides an adapter to transform filters from an API in JSON-API fo
 
 1. **Add the gem to your project:**
 
-   Run the following command to add the gem to your `Gemfile`:
+Run the following command to add the gem to your `Gemfile`:
 
-   ```bash
-   bundle add json_api_active_record_query_adapter
+```bash
+bundle install json_api_active_record_query_adapter
+```
 
 2. **Add the module to your controller:**
 
 ```
-  include JsonApiFilterAdapter
+include JsonApiFilterAdapter
 ```
 
 3. **Example to use the method that will process the data in the controller:**

--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ def index
 end
 ```
 
+## About date filters and the use of `Time.use_zone` in the Code
+
+### `Time.use_zone(JsonApiFilterAdapter.time_zone) { }`:
+- **Purpose**: Temporarily changes the time zone to execute the code inside the block, using the configured time zone (`JsonApiFilterAdapter.time_zone`), ignoring the default time zone.
+- **Context**:
+- This is useful to ensure that date and time operations inside the block are interpreted in the configured time zone, without affecting the rest of the application.
+
+### Block in the code:
+- **Checks and converts date ranges**:
+- **Case with date**: If the value is just a date (`YYYY-MM-DD`), converts the range to the start and end of the day, respecting the configured time zone. - **Case with date and time**: If the value contains a date and time (`YYYY-MM-DD HH:MM..YYYY-MM-DD HH:MM`), process the interval according to the time, keeping the configured time zone.
+- **Case with explicit time zone**: If the value contains a date, time and an explicit time zone, the code processes the interval without modifying the explicit time zone.
+
+- **Ensures consistency**:
+- `Time.use_zone` ensures that all date and time values ​​are converted and handled in the correct time zone (`JsonApiFilterAdapter.time_zone`), regardless of the system's default time zone.
+
+
+
 ## How to test
 
 ```

--- a/json_api_active_record_query_adapter.gemspec
+++ b/json_api_active_record_query_adapter.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name        = "json_api_active_record_query_adapter"
-  s.version     = "1.2.5"
+  s.version     = "1.2.6"
   s.date        = "2023-04-19"
   s.summary     = "Syntax query definition and adapter for using with active record."
   s.description = "Syntax query definition and adapter for using with active record."
-  s.authors     = ["Lucas Hunter"]
+  s.authors     = ["Lucas Hunter, Luiz Filipe, Leonardo Baptista, Rafael C. Abreu"]
   s.email       = "ops@prosas.com.br"
   s.files       = ["lib/json_api_active_record_query_adapter.rb"]
   s.require_paths = ["lib"]

--- a/lib/json_api_active_record_query_adapter.rb
+++ b/lib/json_api_active_record_query_adapter.rb
@@ -1,5 +1,4 @@
 # Biblioteca nativa do Ruby para lidar com parsing e formatação de datas e horas, como Time.parse
-require 'time'
 # TODO: Resolver para o caso de ordenação por colunas de tabelas associadas
 
 # Adpta objeto json para hash de consulta compativél com o active_record

--- a/lib/json_api_active_record_query_adapter.rb
+++ b/lib/json_api_active_record_query_adapter.rb
@@ -15,6 +15,10 @@ require 'time'
 # TODO: Extrair para uma gem
 # TODO: Resolver para o caso de ordenação por colunas de tabelas associadas
 module JsonApiFilterAdapter
+  class << self
+    attr_accessor :time_zone
+  end
+
   VALUE = 1
   KEY = 0
   # Adpta objeto jsonvpara hash de consulta compativél com o active_record
@@ -23,29 +27,33 @@ module JsonApiFilterAdapter
   # >> adpter_from_json_api_to_active_record(object_json_api)
   # >> {"id": 1, "data": Range(Date.parse("01/01/2022"), Date.parse("31/01/2022"))}
   def parse_filter_adapter(data)
-    # data = data_order_formater data, params
-
     data_parsed = {}
     data.each do |parameter|
-      # verifica se valor do filtro é um range
       next unless parameter[VALUE].to_s.include?('..')
 
       first, last = parameter[VALUE].split('..')
+
       case parameter[VALUE]
-      when /^\d{4}-\d{2}-\d{2}..\d{4}-\d{2}-\d{2}$/ # somente com data
-        data_parsed[parameter[KEY]] = Range.new(Date.parse(first), Date.parse(last))
+      when /^\d{4}-\d{2}-\d{2}$/ # somente com data
+        data_parsed[parameter[KEY]] = Range.new(
+          Time.use_zone(JsonApiFilterAdapter.time_zone) { Time.zone.parse(first).beginning_of_day },
+          Time.use_zone(JsonApiFilterAdapter.time_zone) { Time.zone.parse(last).end_of_day }
+        )
       when /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}..\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/ # com data e hora
-        data_parsed[parameter[KEY]] = Range.new(Time.parse(first), Time.parse(last))
-      when /^\d+..\d+$/
-        data_parsed[parameter[KEY]] = Range.new(first.to_i, last.to_i)
-      when /^\d+.\d+..\d+.\d+$/
-        data_parsed[parameter[KEY]] = Range.new(first.to_d, last.to_d)
+        data_parsed[parameter[KEY]] = Range.new(
+          Time.use_zone(JsonApiFilterAdapter.time_zone) { Time.zone.parse(first) },
+          Time.use_zone(JsonApiFilterAdapter.time_zone) { Time.zone.parse(last) }
+        )
+      when /^\d{4}-\d{2}-\d{2} \d{2}:\d{2} \S+$/ # com data, hora e fuso horário
+        data_parsed[parameter[KEY]] = Range.new(
+          Time.use_zone(JsonApiFilterAdapter.time_zone) { Time.zone.parse(first) },
+          Time.use_zone(JsonApiFilterAdapter.time_zone) { Time.zone.parse(last) }
+        )
       end
     end
 
     data.merge!(data_parsed)
-
-    operator_parser_hash_to_array data
+    operator_parser_hash_to_array(data)
   end
 
   private


### PR DESCRIPTION
*[MOTIVAÇÃO]:*
-  Para que as aplicações que utilizam a gem soubesse tratar o `time_zone`, era preciso setar a `ENV='America/Sao_Paulo' `manualmente no Dockerfile dos ambientes. O que não era viável e poderia ocasionar efeitos colaterais em recursos no banco e até mesmo em buscas de dados. 

*[SOLUÇÃO]:*
- Abstraído essa regra de negócio (configuração) diretamente para a `gem`, utilizando como um `initializer` para consultas, quando algum controller incluí módulo `JsonApiFilterAdapter`  chamando o método `parse_filter_adapter`